### PR TITLE
Fix for incorrect status check from builtin HA http server when a file is removed (http status 200 but body_lenght == -1)

### DIFF
--- a/components/ota_http/ota_http.cpp
+++ b/components/ota_http/ota_http.cpp
@@ -136,6 +136,11 @@ void OtaHttpComponent::flash() {
     return;
   }
 
+  if (client_.getSize() < 0) {
+    ESP_LOGD(TAG, "File doesn't exist, aborting");
+    return; 
+  }
+
   body_length = client_.getSize();
   ESP_LOGD(TAG, "firmware is %d bytes length.", body_length);
 

--- a/components/ota_http/ota_http.cpp
+++ b/components/ota_http/ota_http.cpp
@@ -136,12 +136,11 @@ void OtaHttpComponent::flash() {
     return;
   }
 
-  if (client_.getSize() < 0) {
-    ESP_LOGD(TAG, "File doesn't exist, aborting");
-    return; 
-  }
-
   body_length = client_.getSize();
+  if (body_length < 0) {
+    ESP_LOGE(TAG, "Incorect file size (%d) reported by http server (http status: %d). Aborting", body_length, http_code);
+    return;
+  }
   ESP_LOGD(TAG, "firmware is %d bytes length.", body_length);
 
   // flash memory backend

--- a/components/ota_http/ota_http.cpp
+++ b/components/ota_http/ota_http.cpp
@@ -137,8 +137,8 @@ void OtaHttpComponent::flash() {
   }
 
   body_length = client_.getSize();
-  if (body_length < 0) {
-    ESP_LOGE(TAG, "Incorect file size (%d) reported by http server (http status: %d). Aborting", body_length, http_code);
+  if (client_.getSize() < 0) {
+    ESP_LOGE(TAG, "Incorrect file size (%d) reported by http server (http status: %d). Aborting", body_length, http_code);
     return;
   }
   ESP_LOGD(TAG, "firmware is %d bytes length.", body_length);


### PR DESCRIPTION
Not sure why but my ESP32C3 boards would just crash/reboot if the file didn't exist at the provided URL (size returned as -1)

This fixes it, might be a cleaner solution though...